### PR TITLE
chore: swap login and signup button functionality

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -74,7 +74,6 @@ body > div {
   height: 100%;
   max-width: 100vw;
   box-sizing: border-box;
-  padding: 0 10px;
 }
 
 a {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
   const { address } = useAccount();
 
   return (
-    <div className="flex h-full w-96 max-w-full flex-col md:w-[1008px]">
+    <div className="flex h-full w-96 max-w-full flex-col px-1 md:w-[1008px]">
       <section className="mt-6 mb-6 flex w-full flex-col md:flex-row">
         <div className="flex w-full flex-row items-center justify-between gap-2 md:gap-0">
           <a

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -2,5 +2,11 @@
 import WalletWrapper from './WalletWrapper';
 
 export default function LoginButton() {
-  return <WalletWrapper className="min-w-[90px]" text="Log in" />;
+  return (
+    <WalletWrapper
+      className="min-w-[90px]"
+      text="Log in"
+      withWalletAggregator={true}
+    />
+  );
 }

--- a/src/components/SignupButton.tsx
+++ b/src/components/SignupButton.tsx
@@ -6,7 +6,6 @@ export default function SignupButton() {
     <WalletWrapper
       className="ockConnectWallet_Container min-w-[90px] shrink bg-slate-200 text-[#030712] hover:bg-slate-300"
       text="Sign up"
-      withWalletAggregator={true}
     />
   );
 }


### PR DESCRIPTION
**What changed? Why?**
- login should open rainbowkit

https://github.com/user-attachments/assets/d9612648-8825-4e74-b484-b4f7678d0cc9



**Notes to reviewers**

**How has it been tested?**
